### PR TITLE
画像が読み込まれてない時にクリックで縮むバグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,15 +428,16 @@
       reset.addEventListener(
         'click',
         function () {
+          if (!img.src) {
+            return;
+          }
           var preview = document.getElementById('animated-preview');
           preview.style.display = 'none';
 
           clickedPosList = [];
 
-          if (img.src) {
-            setCanvasWidthHeight();
-            drawBaseImage(context);
-          }
+          setCanvasWidthHeight();
+          drawBaseImage(context);
         },
         true
       );
@@ -444,6 +445,9 @@
       redraw.addEventListener(
         'click',
         function () {
+          if (!img.src) {
+            return;
+          }
           setCanvasWidthHeight();
           drawBaseImage(context);
           // 静止画 canvas を更新
@@ -494,6 +498,9 @@
       canvas.addEventListener(
         'click',
         function (e) {
+          if (!img.src) {
+            return;
+          }
           desc.textContent = "光らせた画像は、右クリックメニューから保存できるよ！";
           clickedPosList.push({
             x: e.pageX - e.target.offsetLeft - 2,


### PR DESCRIPTION
#1 で修正しきれてませんでした。
「もういっかい描画」ボタンと canvas のクリック時にも縮んでしまうので修正しました。